### PR TITLE
Correct callback usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 🚧 WIP: I'm in the process of improving this fork of the original source now it has been archived to keep it alive and to make it more useful and reliable.
 
+**NOTE:** The configuration keys have changed slightly in this fork to use snake_case.
+
 Please consider signing up to Octopus Energy with my referral code: <https://share.octopus.energy/mauve-ash-375> to give you and me £50 credit in the mean time.
 
 Want to motivate me to improve this quicker? [Sponsor me](https://github.com/sponsors/lildude) to work on it 😉 💖

--- a/apps/octocost/octocost.py
+++ b/apps/octocost/octocost.py
@@ -82,7 +82,7 @@ class OctoCost(hass.Hass):
         url = f"{BASEURL}/{energy}-meter-points/{meter_point}/meters/{serial}/consumption/"
         return url
 
-    def cost_and_usage_callback(self, **kwargs):
+    def cost_and_usage_callback(self, kwargs):
         self.use_url = kwargs.get("use")
         self.cost_url = kwargs.get("cost")
         self.start_date = kwargs.get("date")

--- a/tests/test_octocost.py
+++ b/tests/test_octocost.py
@@ -171,9 +171,11 @@ def test_callback_sets_electricity_states(hass_driver, octocost: OctoCost):
     octocost.calculate_cost_and_usage = Mock(return_value=[7.7, 109.0])
 
     octocost.cost_and_usage_callback(
-        use=octocost.consumption_url(),
-        cost=octocost.tariff_url(),
-        date=datetime.date(2020, 12, 27),
+        {
+            "use": octocost.consumption_url(),
+            "cost": octocost.tariff_url(),
+            "date": datetime.date(2020, 12, 27),
+        }
     )
 
     set_state.assert_any_call(
@@ -214,9 +216,11 @@ def test_callback_sets_gas_states(hass_driver, octocost: OctoCost):
     octocost.calculate_cost_and_usage = Mock(return_value=[7.7, 150.8])
 
     octocost.cost_and_usage_callback(
-        use=octocost.consumption_url("gas"),
-        cost=octocost.tariff_url(energy="gas", tariff=octocost.gas_tariff),
-        date=datetime.date(2020, 12, 27),
+        {
+            "use": octocost.consumption_url("gas"),
+            "cost": octocost.tariff_url(energy="gas", tariff=octocost.gas_tariff),
+            "date": datetime.date(2020, 12, 27),
+        }
     )
 
     set_state.assert_any_call(


### PR DESCRIPTION
Correct callback usage to resolve this warning:

```
2021-01-26 11:54:00.018249 WARNING octocost: Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/appdaemon/threading.py", line 887, in worker
    funcref(self.AD.sched.sanitize_timer_kwargs(app, args["kwargs"]))
TypeError: cost_and_usage_callback() takes 1 positional argument but 2 were given
```