### PR TITLE
Add support for a comparison electricity tariff

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@ Want to motivate me to improve this quicker? [Sponsor me](https://github.com/spo
 
 ## Summary
 
-Octocost is an [AppDaemon](https://www.home-assistant.io/docs/ecosystem/appdaemon/) app for [Home Assistant](https://www.home-assistant.io/) which calculates the daily, monthly and yearly cost and usage of the Octopus Energy tariffs.
+Octocost is an [AppDaemon](https://www.home-assistant.io/docs/ecosystem/appdaemon/) app for [Home Assistant](https://www.home-assistant.io/) which calculates the daily, monthly and yearly cost and usage of the Octopus Energy tariffs. 
 
-It creates and sets sensors for daily, monthly and yearly cost (£) and usage (kWh), up to and including yesterday:
+By default OctoCost only gathers usage and cost information for the current (as of Jan 2021) Agile tariff: `AGILE-18-02-21` but can be configured to gather usage and cost information for an another electricity tariff, giving you the opportunity to compare your current tariff to the Agile tariff.
+
+Usage and cost information can also be gathered for a gas tariff.
+
+OctoCost creates and sets sensors for daily, monthly and yearly cost (£) and usage (kWh), up to and including yesterday:
 
 ```yaml
 sensor.octopus_daily_cost
@@ -27,7 +31,15 @@ sensor.octopus_yearly_cost
 sensor.octopus_yearly_usage
 ```
 
-If can also pull monthly and yearly gas cost and usage, and have sensors for them set up, if the gas section is included in the yaml configuration:
+If a comparison electricity tariff is configured, OctoCost will also create the following sensors:
+
+```yaml
+sensor.octopus_comparison_daily_cost
+sensor.octopus_comparison_monthly_cost
+sensor.octopus_comparison_yearly_cost
+```
+
+If the gas section is configured, OctoCost will also create the following sensors:
 
 ```yaml
 sensor.octopus_monthly_gas_cost
@@ -53,6 +65,7 @@ octocost:
   serial:  <Serial number>
   auth: <Octopus Energy API Key>
   start_date: 2020-02-23
+  comparison_tariff: FIX-12M-20-02-12
   gas:
     mprn: <Gas MPRN number>
     gas_serial: <Gas meter serial number>
@@ -62,21 +75,22 @@ octocost:
 
 The module and class sections need to remain as above, other sections should be changed as required. The whole gas section is optional and can be excluded if not required.
 
-| Field          | Changeable | Example          |
-| -----          | ---------- | -------          |
-| Title          | Yes        | octocost         |
-| module         | No         | octocost         |
-| class          | No         | OctoCost         |
-| region         | Yes        | H                |
-| mpan           | Yes        | 2000012345678    |
-| serial         | Yes        | 20L123456        |
-| auth           | Yes        | sk_live_abcdefg  |
-| start_date     | Yes        | 2020-02-23       |
-| gas:           | Yes        |                  |
-| mprn           | Yes        | 1234567890       |
-| gas_serial     | Yes        | E1S12345678901   |
-| gas_tariff     | Yes        | FIX-12M-20-02-12 |
-| gas_start_date | Yes        | 2020-02-23       |
+| Field             | Changeable | Example          |
+| -----             | ---------- | -------          |
+| Title             | Yes        | octocost         |
+| module            | No         | octocost         |
+| class             | No         | OctoCost         |
+| region            | Yes        | H                |
+| mpan              | Yes        | 2000012345678    |
+| serial            | Yes        | 20L123456        |
+| auth              | Yes        | sk_live_abcdefg  |
+| start_date        | Yes        | 2020-02-23       |
+| comparison_tariff | Yes        | FIX-12M-20-02-12 |
+| gas:              | Yes        |                  |
+| mprn              | Yes        | 1234567890       |
+| gas_serial        | Yes        | E1S12345678901   |
+| gas_tariff        | Yes        | FIX-12M-20-02-12 |
+| gas_start_date    | Yes        | 2020-02-23       |
 
 The `start_date` setting should be set to the date you started on the Agile Octopus tariff, not the date you joined Octopus Energy. It is used to adjust the start point if you joined within the current year or month, it should not be left blank if you joined earlier.
 `region` is the region letter from the end of `E-1R-AGILE-18-02-21-H` which can be found on the [Octopus Energy developer dashboard](https://octopus.energy/dashboard/developer/) webpage in the Unit Rates section for your account.

--- a/tests/test_octocost.py
+++ b/tests/test_octocost.py
@@ -4,8 +4,9 @@ from unittest.mock import Mock
 
 import pytest
 from appdaemon_testing.pytest import automation_fixture
-from apps.octocost.octocost import OctoCost
 from freezegun import freeze_time
+
+from apps.octocost.octocost import OctoCost
 
 
 @automation_fixture(
@@ -16,6 +17,7 @@ from freezegun import freeze_time
         "region": "H",
         "serial": "67890",
         "start_date": "2020-12-27",
+        "comparison_tariff": "FIX-12M-20-09-21",
         "gas": {
             "mprn": "54321",
             "gas_serial": "98765",
@@ -145,6 +147,13 @@ def test_callbacks_run_in(hass_driver, octocost: OctoCost):
         cost="https://api.octopus.energy/v1/products/AGILE-18-02-21/electricity-tariffs/E-1R-AGILE-18-02-21-H/standard-unit-rates/",
         date=datetime.date(2020, 12, 27),
     )
+    run_in.assert_any_call(
+        octocost.cost_and_usage_callback,
+        6,
+        use="https://api.octopus.energy/v1/electricity-meter-points/12345/meters/67890/consumption/",
+        cost="https://api.octopus.energy/v1/products/FIX-12M-20-09-21/electricity-tariffs/E-1R-FIX-12M-20-09-21-H/standard-unit-rates/",
+        date=datetime.date(2020, 12, 27),
+    )
 
 
 def test_callbacks_run_daily(hass_driver, octocost: OctoCost):
@@ -154,6 +163,13 @@ def test_callbacks_run_daily(hass_driver, octocost: OctoCost):
         datetime.time(0, 5),
         use="https://api.octopus.energy/v1/electricity-meter-points/12345/meters/67890/consumption/",
         cost="https://api.octopus.energy/v1/products/AGILE-18-02-21/electricity-tariffs/E-1R-AGILE-18-02-21-H/standard-unit-rates/",
+        date=datetime.date(2020, 12, 27),
+    )
+    run_daily.assert_any_call(
+        octocost.cost_and_usage_callback,
+        datetime.time(0, 6),
+        use="https://api.octopus.energy/v1/electricity-meter-points/12345/meters/67890/consumption/",
+        cost="https://api.octopus.energy/v1/products/FIX-12M-20-09-21/electricity-tariffs/E-1R-FIX-12M-20-09-21-H/standard-unit-rates/",
         date=datetime.date(2020, 12, 27),
     )
     run_daily.assert_any_call(
@@ -205,6 +221,53 @@ def test_callback_sets_electricity_states(hass_driver, octocost: OctoCost):
     )
     set_state.assert_any_call(
         "sensor.octopus_daily_cost",
+        state=1.09,
+        attributes={"unit_of_measurement": "£", "icon": "mdi:cash"},
+    )
+
+
+@freeze_time("2021-02-01")
+def test_callback_sets_comparison_electricity_states(hass_driver, octocost: OctoCost):
+    set_state = hass_driver.get_mock("set_state")
+    octocost.calculate_cost_and_usage = Mock(return_value=[7.7, 109.0])
+
+    octocost.cost_and_usage_callback(
+        {
+            "use": octocost.consumption_url(),
+            "cost": octocost.tariff_url(
+                energy="electricity", tariff=octocost.comparison_tariff
+            ),
+            "date": datetime.date(2020, 12, 27),
+        }
+    )
+
+    set_state.assert_any_call(
+        "sensor.octopus_yearly_usage",
+        state=7.7,
+        attributes={"unit_of_measurement": "kWh", "icon": "mdi:flash"},
+    )
+    set_state.assert_any_call(
+        "sensor.octopus_monthly_usage",
+        state=7.7,
+        attributes={"unit_of_measurement": "kWh", "icon": "mdi:flash"},
+    )
+    set_state.assert_any_call(
+        "sensor.octopus_comparison_yearly_cost",
+        state=1.09,
+        attributes={"unit_of_measurement": "£", "icon": "mdi:cash"},
+    )
+    set_state.assert_any_call(
+        "sensor.octopus_daily_usage",
+        state=7.7,
+        attributes={"unit_of_measurement": "kWh", "icon": "mdi:flash"},
+    )
+    set_state.assert_any_call(
+        "sensor.octopus_comparison_monthly_cost",
+        state=1.09,
+        attributes={"unit_of_measurement": "£", "icon": "mdi:cash"},
+    )
+    set_state.assert_any_call(
+        "sensor.octopus_comparison_daily_cost",
         state=1.09,
         attributes={"unit_of_measurement": "£", "icon": "mdi:cash"},
     )

--- a/tests/test_octocost.py
+++ b/tests/test_octocost.py
@@ -109,7 +109,7 @@ def test_calculate_cost_and_usage_standard_unit_rate_gas_only(octocost: OctoCost
 def test_calculate_cost_and_usage_standard_unit_rate_elec_only(octocost: OctoCost):
     octocost.yesterday = datetime.date(2021, 1, 18)
     octocost.use_url = octocost.consumption_url()
-    octocost.cost_url = octocost.tariff_url(tariff=octocost.gas_tariff)
+    octocost.cost_url = octocost.tariff_url(tariff=octocost.comparison_tariff)
     start_day = datetime.date(2021, 1, 18)
 
     usage, cost = octocost.calculate_cost_and_usage(start_day)


### PR DESCRIPTION
Peeps might want to compare their current fixed or other rate tariff against the Agile tariff to see if they could save money. This PR add support for configuring another tariff to query and report.